### PR TITLE
Get Metal device from layerRenderer

### DIFF
--- a/FullyImmersiveMetal/FullyImmersiveMetal/SpatialRenderer.mm
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/SpatialRenderer.mm
@@ -20,7 +20,7 @@ SpatialRenderer::SpatialRenderer(cp_layer_renderer_t layerRenderer) :
     _sceneTime(0.0),
     _lastRenderTime(CACurrentMediaTime())
 {
-    _device = MTLCreateSystemDefaultDevice();
+    _device = cp_layer_renderer_get_device(layerRenderer);
     _commandQueue = [_device newCommandQueue];
 
     makeResources();


### PR DESCRIPTION
cp_layer_renderer_get_device() returns "the Metal device to use for your drawing operations". Using the returned Metal device instead of creating the system default device should provide better compatibility, even it doesn't really make a difference on current Apple Silicon devices.

Here is the Apple doc I referred to: https://developer.apple.com/documentation/compositorservices/4241220-cp_layer_renderer_get_device?changes=latest_minor__7&language=objc