### PR TITLE
Demonstrate how to use the 'layered' and 'shared' layouts

### DIFF
--- a/FullyImmersiveMetal/FullyImmersiveMetal/App.swift
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/App.swift
@@ -7,6 +7,9 @@ struct MetalLayerConfiguration: CompositorLayerConfiguration {
     {
         let supportsFoveation = capabilities.supportsFoveation
         //let supportedLayouts = capabilities.supportedLayouts(options: supportsFoveation ? [.foveationEnabled] : [])
+        
+        // The device supports the `dedicated` and `layered` layouts.
+        // The simulator supports the `dedicated` and `shared` layouts.
         configuration.layout = .dedicated
         configuration.isFoveationEnabled = supportsFoveation
         configuration.colorFormat = .rgba16Float

--- a/FullyImmersiveMetal/FullyImmersiveMetal/EnvironmentShaders.metal
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/EnvironmentShaders.metal
@@ -12,6 +12,8 @@ struct VertexOut {
     float4 position [[position]];
     float3 modelNormal;
     float2 texCoords;
+    uint layer [[ render_target_array_index ]];
+    uint viewport [[ viewport_array_index ]];
 };
 
 struct PoseConstants {
@@ -26,13 +28,19 @@ struct EnvironmentConstants {
 
 [[vertex]]
 VertexOut vertex_environment(VertexIn in [[stage_in]],
-                             constant PoseConstants &pose [[buffer(1)]],
-                             constant EnvironmentConstants &environment [[buffer(2)]])
+                             constant PoseConstants *poses [[buffer(1)]],
+                             constant EnvironmentConstants &environment [[buffer(2)]],
+                             const uint instance_id [[ instance_id ]])
 {
     VertexOut out;
+    
+    const constant auto& pose = poses[instance_id];
+    
     out.position = pose.projectionMatrix * pose.viewMatrix * float4(in.position, 1.0f);
     out.modelNormal = -in.normal;
     out.texCoords = in.texCoords;
+    out.layer = instance_id;
+    out.viewport = instance_id;
     return out;
 }
 

--- a/FullyImmersiveMetal/FullyImmersiveMetal/Mesh.h
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/Mesh.h
@@ -9,7 +9,9 @@
 class Mesh {
 public:
     virtual MTLVertexDescriptor *vertexDescriptor() const;
-    virtual void draw(id<MTLRenderCommandEncoder> renderCommandEncoder, PoseConstants poseConstants) = 0;
+    virtual void draw(id<MTLRenderCommandEncoder> renderCommandEncoder,
+                      const PoseConstants *poseConstants, const LayerConstants *layerConstants,
+                      NSUInteger instanceCount) = 0;
 
     simd_float4x4 modelMatrix() const { return _modelMatrix; }
 
@@ -24,7 +26,9 @@ public:
     TexturedMesh();
     TexturedMesh(MDLMesh *mdlMesh, NSString *imageName, id<MTLDevice> device);
 
-    void draw(id<MTLRenderCommandEncoder> renderCommandEncoder, PoseConstants poseConstants) override;
+    void draw(id<MTLRenderCommandEncoder> renderCommandEncoder,
+              const PoseConstants *poseConstants, const LayerConstants *layerContants,
+              NSUInteger instanceCount) override;
 
 protected:
     MTKMesh *_mesh;
@@ -34,7 +38,9 @@ protected:
 class SpatialEnvironmentMesh: public TexturedMesh {
 public:
     SpatialEnvironmentMesh(NSString *imageName, CGFloat radius, id<MTLDevice> device);
-    void draw(id<MTLRenderCommandEncoder> renderCommandEncoder, PoseConstants poseConstants) override;
+    void draw(id<MTLRenderCommandEncoder> renderCommandEncoder, 
+              const PoseConstants *poseConstants, const LayerConstants *layerContants,
+              NSUInteger instanceCount) override;
 
 private:
     simd_float4x4 _environmentRotation;

--- a/FullyImmersiveMetal/FullyImmersiveMetal/SceneShaders.metal
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/SceneShaders.metal
@@ -12,6 +12,8 @@ struct VertexOut {
     float4 position [[position]];
     float3 viewNormal;
     float2 texCoords;
+    uint layer [[ render_target_array_index ]];
+    uint viewport [[ viewport_array_index ]];
 };
 
 struct PoseConstants {
@@ -23,16 +25,27 @@ struct InstanceConstants {
     float4x4 modelMatrix;
 };
 
+struct LayerConstants {
+    unsigned layerCount, viewportCount;
+};
+
 [[vertex]]
 VertexOut vertex_main(VertexIn in [[stage_in]],
-                             constant PoseConstants &pose [[buffer(1)]],
-                             constant InstanceConstants &instance [[buffer(2)]])
+                      constant PoseConstants *poses [[buffer(1)]],
+                      constant InstanceConstants &instance [[buffer(2)]],
+                      constant LayerConstants &layer [[buffer(3)]],
+                      const uint instance_id [[ instance_id ]])
 {
     VertexOut out;
+    
+    const constant auto& pose = poses[instance_id];
+        
     out.position = pose.projectionMatrix * pose.viewMatrix * instance.modelMatrix * float4(in.position, 1.0f);
     out.viewNormal = (pose.viewMatrix * instance.modelMatrix * float4(in.normal, 0.0f)).xyz;
     out.texCoords = in.texCoords;
     out.texCoords.x = 1.0f - out.texCoords.x; // Flip uvs horizontally to match Model I/O
+    out.layer = instance_id % layer.layerCount;
+    out.viewport = instance_id % layer.viewportCount;
     return out;
 }
 

--- a/FullyImmersiveMetal/FullyImmersiveMetal/ShaderTypes.h
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/ShaderTypes.h
@@ -11,6 +11,10 @@ struct InstanceConstants {
     simd_float4x4 modelMatrix;
 };
 
+struct LayerConstants {
+    unsigned layerCount, viewportCount;
+};
+
 struct EnvironmentConstants {
     simd_float4x4 modelMatrix;
     simd_float4x4 environmentRotation;

--- a/FullyImmersiveMetal/FullyImmersiveMetal/SpatialRenderer.h
+++ b/FullyImmersiveMetal/FullyImmersiveMetal/SpatialRenderer.h
@@ -15,8 +15,9 @@ public:
 
 private:
     void makeResources();
-    void makeRenderPipelines(cp_layer_renderer_layout layout);
+    void makeRenderPipelines();
     MTLRenderPassDescriptor* createRenderPassDescriptor(cp_drawable_t drawable, size_t index);
+    MTLViewport viewportForViewIndex(cp_drawable_t drawable, size_t index);
     PoseConstants poseConstantsForViewIndex(cp_drawable_t drawable, size_t index);
 
     id<MTLDevice> _device;
@@ -26,6 +27,7 @@ private:
     id<MTLDepthStencilState> _contentDepthStencilState;
     id<MTLDepthStencilState> _backgroundDepthStencilState;
     cp_layer_renderer_t _layerRenderer;
+    cp_layer_renderer_layout _layerRendererLayout;
     std::unique_ptr<TexturedMesh> _globeMesh;
     std::unique_ptr<SpatialEnvironmentMesh> _environmentMesh;
     CFTimeInterval _sceneTime;

--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 
 This sample is a minimal example of rendering a fully immersive spatial experience with Metal, ARKit, and visionOS Compositing Services.
 
+Modify the [`layout` property of `LayerRenderer.Configuration` in 'App.swift'][1] to try different compositing modes:
+
+* `dedicated` renders the scene in two passes to two different textures. It is supported by both the device and the simulator.
+
+* `layered` renders the scene in a single pass to a single array texture by setting `render_target_array_index` in the vertex shader. It is supported only by the device.
+
+* `shared` renders the scene in a single pass to a single texture by setting `viewport_array_index` in the vertex shader. It is supported only by the simulator.
+
 ![Example screenshot of spatial rendering](screenshots/01.png)
+
+[1]: ./FullyImmersiveMetal/FullyImmersiveMetal/App.swift#L13


### PR DESCRIPTION
These changes demonstrate how to enable the `layered` and `shared` compositor layouts & render the scene in a single pass:

* For the `layered` layout, the framebuffer is an array texture. The shader sets `render_target_array_index` to specify which 'slice' of the array texture to render into.

* For the `shared` layout, the framebuffer is a single texture. The shader sets `viewport_array_index` to specify which portion of the texture to render into.

* Mesh drawing uses 'instanced' rendering. `Mesh::draw()` accepts an `instanceCount` that specifies the number of instances to draw. `SpatialRenderer` passes the 'view count' for the drawable as this argument.

* The vertex shader interprets `instance_id` as the 'eye' being rendered. It uses this value to set `render_target_array_index` and `viewport_array_index`.

Note that the `layered` layout is supported only by the Vision Pro device, and the `shared` layout is supported only by the Vision Pro simulator.